### PR TITLE
make active steam transfer dependent on steam production

### DIFF
--- a/src/main/java/chiefarug/mods/systeams/block_entities/BoilerBlockEntityBase.java
+++ b/src/main/java/chiefarug/mods/systeams/block_entities/BoilerBlockEntityBase.java
@@ -162,7 +162,7 @@ public abstract class BoilerBlockEntityBase extends AugmentableBlockEntity imple
 		// steam. note this is lossy if there is not enough space in the tank. that is fine, because if someone is letting that happen too often that is their fault.
 		steamTank.fill(newSteam, EXECUTE);
 
-		transferSteamOut(TRANSFER_PER_TICK);
+		transferSteamOut(steamPerTick * 2);
 	}
 
 	/**


### PR DESCRIPTION
While playing Star Technologies I discovered that it is possible to upgrade the stirling boiler to 3200 mB/t which caused it to stop working as that was above it's transfer rate.

So instead use 2x the production rate while active.